### PR TITLE
Sanitize file path components to be compatible with Microsoft Windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -635,7 +635,9 @@ func getSongPath(song resSongInfoData, album resAlbum, config configuration) str
 	if err != nil { panic(err) }
 	rawPath := fmt.Sprintf("%s/%s/%s - %s [WEB FLAC]/%02d - %s.flac", config.DestDir,
 		cleanArtist, cleanArtist, cleanAlbumTitle, trackNum, cleanSongTitle)
-	return path.Clean(rawPath)
+	rawPath = strings.ReplaceAll(path.Clean(rawPath), "&", "and")
+	rawPath = strings.ReplaceAll(path.Clean(rawPath), ": ", "- ")
+	return rawPath
 }
 
 func calcBfKey(songId []byte, config configuration) []byte {


### PR DESCRIPTION
As a (somewhat reluctant) new Windows user, I hit upon issues using this tool due to differences in illegal characters in file paths.

This was battle tested. Please check my Go code for good practices, I am not very familiar with the ecosystem.